### PR TITLE
chore(deps): bump ws security patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
             "dependencies": {
                 "@types/ws": "^8.5.10",
                 "uuid": "^9.0.1",
-                "ws": "^8.16.0"
+                "ws": "^8.20.1"
             },
             "devDependencies": {
                 "@types/node": "20.11.20",
@@ -3556,9 +3556,10 @@
             "dev": true
         },
         "node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+            "version": "8.20.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+            "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "dependencies": {
         "@types/ws": "^8.5.10",
         "uuid": "^9.0.1",
-        "ws": "^8.16.0"
+        "ws": "^8.20.1"
     },
     "devDependencies": {
         "@types/node": "20.11.20",


### PR DESCRIPTION
Fixes the open ws Dependabot alert by bumping ws to 8.20.1.\n\nValidation:\n- npm ci --ignore-scripts --no-audit --no-fund\n- npm run lint\n- npm run build\n\nNote: local validation was run under Node 24; npm emitted the existing homebridge engine warning for Node 18/20 support but completed successfully.