### PR TITLE
Remove unused uuid dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
             "license": "MIT",
             "dependencies": {
                 "@types/ws": "^8.5.10",
-                "uuid": "^9.0.1",
                 "ws": "^8.20.1"
             },
             "devDependencies": {
@@ -3360,18 +3359,6 @@
             "dev": true,
             "dependencies": {
                 "punycode": "^2.1.0"
-            }
-        },
-        "node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     ],
     "dependencies": {
         "@types/ws": "^8.5.10",
-        "uuid": "^9.0.1",
         "ws": "^8.20.1"
     },
     "devDependencies": {


### PR DESCRIPTION
Addresses Dependabot alert #37 for uuid by removing the unused direct runtime dependency instead of carrying it forward.\n\nValidation:\n- npm ci --ignore-scripts --no-audit --no-fund\n- npm run lint\n- npm run build\n- npm audit --omit=dev --audit-level=moderate