### PR TITLE
Fix js-yaml security advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
                 "@typescript-eslint/parser": "7.1.0",
                 "eslint": "8.57.0",
                 "homebridge": "^1.7.0",
+                "js-yaml": "^4.3.0",
                 "nodemon": "^3.1.0",
                 "rimraf": "5.0.5",
                 "ts-node": "^10.9.2",
@@ -2203,9 +2204,9 @@
             }
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
             "funding": [
                 {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "@typescript-eslint/parser": "7.1.0",
         "eslint": "8.57.0",
         "homebridge": "^1.7.0",
+        "js-yaml": "^4.3.0",
         "nodemon": "^3.1.0",
         "rimraf": "5.0.5",
         "ts-node": "^10.9.2",


### PR DESCRIPTION
Updates the development dependency resolution for `js-yaml` to 4.3.0, fixing Dependabot alert #39 (GHSA-52cp-r559-cp3m).